### PR TITLE
Potential fix for code scanning alert no. 2: CORS misconfiguration for credentials transfer

### DIFF
--- a/frontend/src/middleware/security.js
+++ b/frontend/src/middleware/security.js
@@ -239,14 +239,23 @@ const corsHandler = (req, res, next) => {
 
     // For development, allow localhost
     if (process.env.NODE_ENV === 'development') {
-        res.setHeader('Access-Control-Allow-Origin', origin || '*');
+        // Define a whitelist of allowed origins for development
+        const devAllowedOrigins = [
+            'http://localhost:3000',
+            'http://127.0.0.1:3000',
+            'http://localhost:5173',
+            'http://127.0.0.1:5173'
+        ];
+        if (origin && devAllowedOrigins.includes(origin) && origin !== 'null') {
+            res.setHeader('Access-Control-Allow-Origin', origin);
+        }
     } else {
         // In production, be more restrictive
         const allowedOrigins = process.env.ALLOWED_ORIGINS ?
             process.env.ALLOWED_ORIGINS.split(',') :
             [];
 
-        if (origin && allowedOrigins.includes(origin)) {
+        if (origin && allowedOrigins.includes(origin) && origin !== 'null') {
             res.setHeader('Access-Control-Allow-Origin', origin);
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/GoodOlClint/dogecoin-node/security/code-scanning/2](https://github.com/GoodOlClint/dogecoin-node/security/code-scanning/2)

To fix the problem, the code must ensure that when `Access-Control-Allow-Credentials` is set to `'true'`, the `Access-Control-Allow-Origin` header is never set to `"*"` or `"null"`, and is only set to a trusted, whitelisted origin. In development, instead of allowing any origin or `"*"`, the code should use a whitelist of allowed origins (e.g., `http://localhost:3000`, `http://127.0.0.1:3000`, etc.), and only set the header if the request's `Origin` matches one of these. In production, the existing logic using `ALLOWED_ORIGINS` can be kept, but should also ensure `"null"` is not allowed. The fix should be applied in the `corsHandler` function, specifically lines 241-243, and should sanitize the `origin` value before reflecting it.

**Required changes:**
- Define a whitelist of allowed origins for development.
- Only set `Access-Control-Allow-Origin` if the request's `Origin` is in the whitelist (for both development and production).
- Never set `Access-Control-Allow-Origin` to `"*"` or `"null"` when credentials are allowed.
- Optionally, log a warning if an untrusted origin is encountered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
