### PR TITLE
Potential fix for code scanning alert no. 747: Log injection

### DIFF
--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -200,7 +200,9 @@ class DogecoinMonitor {
             try {
                 message = JSON.parse(event.data);
                 // Log only safe metadata, not raw user data
-                console.log('WebSocket message received, type:', message.type || 'unknown');
+                // Sanitize message.type to prevent log injection
+                const safeType = (typeof message.type === 'string' ? message.type.replace(/[\n\r]/g, '') : 'unknown');
+                console.log('WebSocket message received, type (user input sanitized):', safeType);
             } catch {
                 console.log('WebSocket message received (invalid JSON)');
                 return; // Exit early if JSON is invalid


### PR DESCRIPTION
Potential fix for [https://github.com/GoodOlClint/dogecoin-node/security/code-scanning/747](https://github.com/GoodOlClint/dogecoin-node/security/code-scanning/747)

To fix the log injection vulnerability, we should sanitize the `message.type` value before logging it. Specifically, we should remove any newline (`\n`) or carriage return (`\r`) characters from the string, as these can be used to forge new log entries. The best way to do this is to use `String.prototype.replace` with a regular expression to strip these characters. We should also ensure that the value is clearly marked as user input in the log entry. The change should be made in the `connectWebSocket` method, specifically on line 203 in `frontend/public/app.js`. No new imports are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
