### PR TITLE
Potential fix for code scanning alert no. 748: Disallow the use of undeclared variables unless mentioned in `/*global */` comments

### DIFF
--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -305,7 +305,7 @@ return;
             console.log('Fetching /api/blocks/10...');
             try {
                 const blocksResponse = await fetch('/api/blocks/10', { 
-                    signal: AbortSignal.timeout(15000) // 15 second timeout
+                    signal: this.getTimeoutSignal(15000) // 15 second timeout
                 });
                 if (blocksResponse.ok) {
                     const blocks = await blocksResponse.json();


### PR DESCRIPTION
Potential fix for [https://github.com/GoodOlClint/dogecoin-node/security/code-scanning/748](https://github.com/GoodOlClint/dogecoin-node/security/code-scanning/748)

To fix the problem, we need to ensure that `AbortSignal` is defined in the environment where this code runs. The best way to do this is to check for the existence of `AbortSignal.timeout` before using it, and provide a fallback for browsers that do not support it. One common fallback is to use a manual timeout with `Promise.race` and an `AbortController`. 

The fix should be applied in the `frontend/public/app.js` file, specifically in the `loadInitialData` method where `AbortSignal.timeout(15000)` is used. We will replace the direct use of `AbortSignal.timeout` with a helper function that provides the same functionality, using native `AbortSignal.timeout` if available, or a polyfill otherwise. We will define this helper function within the class or as a static method, and use it to create the signal for the fetch call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
